### PR TITLE
Allow building on stable Rust

### DIFF
--- a/workspace/assembler/Cargo.toml
+++ b/workspace/assembler/Cargo.toml
@@ -20,3 +20,10 @@ version = "0.10.1"
 [dependencies]
 libc = "^0.2"
 likely = "^0.1"
+
+[dev-dependencies]
+criterion = "0.2.11"
+
+[[bench]]
+name = "performance_tests"
+harness = false

--- a/workspace/assembler/Cargo.toml
+++ b/workspace/assembler/Cargo.toml
@@ -19,7 +19,6 @@ version = "0.10.1"
 
 [dependencies]
 libc = "^0.2"
-likely = "^0.1"
 
 [dev-dependencies]
 criterion = "0.2.11"

--- a/workspace/assembler/benches/performance_tests.rs
+++ b/workspace/assembler/benches/performance_tests.rs
@@ -1,0 +1,46 @@
+extern crate assembler;
+extern crate criterion;
+
+use assembler::{
+  ExecutableAnonymousMemoryMap,
+  InstructionStreamHints
+};
+
+use criterion::{
+  criterion_group,
+  criterion_main,
+  Criterion,
+  black_box
+};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("simple function", |b| b.iter(|| {
+      let mut map = ExecutableAnonymousMemoryMap::new(4096, false, false).expect("Could not anonymously mmap");
+      
+      let _function_pointer =
+      {
+        let mut instruction_stream = map.instruction_stream(&InstructionStreamHints::default());
+        
+        instruction_stream.emit_alignment(64);
+        
+        let function_pointer: unsafe extern "C" fn() -> i32 = instruction_stream.nullary_function_pointer();
+        
+        instruction_stream.push_stack_frame();
+        
+        instruction_stream.zero_RAX();
+        
+        instruction_stream.pop_stack_frame_and_return();
+        
+        let (encoded_bytes, _hints) = instruction_stream.finish();
+        
+       
+        function_pointer
+      };
+      
+      let result = unsafe { _function_pointer() };
+    })
+  );
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/workspace/assembler/src/ByteEmitter.rs
+++ b/workspace/assembler/src/ByteEmitter.rs
@@ -132,7 +132,7 @@ impl ByteEmitter
 		const Minimum: isize = ::std::i8::MIN as isize;
 		const Maximum: isize = ::std::i8::MAX as isize;
 		
-		if unlikely!(displacement < Minimum || displacement > Maximum)
+		if displacement < Minimum || displacement > Maximum
 		{
 			return Err(())
 		}
@@ -152,7 +152,7 @@ impl ByteEmitter
 		const Minimum: isize = ::std::i32::MIN as isize;
 		const Maximum: isize = ::std::i32::MAX as isize;
 		
-		if unlikely!(displacement < Minimum || displacement > Maximum)
+		if displacement < Minimum || displacement > Maximum
 		{
 			return Err(())
 		}

--- a/workspace/assembler/src/ExecutableAnonymousMemoryMap.rs
+++ b/workspace/assembler/src/ExecutableAnonymousMemoryMap.rs
@@ -70,7 +70,7 @@ impl ExecutableAnonymousMemoryMap
 		};
 		
 		let result = unsafe { mmap(null_mut(), aligned_length, PROT_NONE, flags, NoFileDescriptor, NoOffset) };
-		if unlikely!(result == MAP_FAILED)
+		if result == MAP_FAILED
 		{
 			Err(MMapFailed(io::Error::last_os_error(), aligned_length))
 		}
@@ -78,9 +78,9 @@ impl ExecutableAnonymousMemoryMap
 		{
 			let address = result;
 			let result = unsafe { mlock(address, length) };
-			if unlikely!(!ignore_mlock_failure && result != 0)
+			if !ignore_mlock_failure && result != 0
 			{
-				if likely!(result == -1)
+				if result == -1
 				{
 					return Err(MLockFailed(io::Error::last_os_error(), aligned_length))
 				}

--- a/workspace/assembler/src/InstructionStream.rs
+++ b/workspace/assembler/src/InstructionStream.rs
@@ -770,7 +770,7 @@ impl<'a> InstructionStream<'a>
 	fn reserve_space(&mut self, length: usize)
 	{
 		let remaining_space = self.byte_emitter.remaining_space();
-		if unlikely!(remaining_space < length)
+		if remaining_space < length
 		{
 			if self.attempt_to_resize_in_place().is_err()
 			{

--- a/workspace/assembler/src/LabelledLocations.rs
+++ b/workspace/assembler/src/LabelledLocations.rs
@@ -50,7 +50,7 @@ impl LabelledLocations
 	#[inline(always)]
 	pub(crate) fn create_label(&mut self) -> Label
 	{
-		if unlikely!(self.next_label_index == self.length)
+		if self.next_label_index == self.length
 		{
 			self.resize()
 		}

--- a/workspace/assembler/src/lib.rs
+++ b/workspace/assembler/src/lib.rs
@@ -7,7 +7,6 @@
 #![allow(non_camel_case_types)]
 #![deny(missing_docs)]
 #![deny(unreachable_patterns)]
-#![feature(core_intrinsics)]
 
 
 //! #assembler
@@ -57,7 +56,6 @@
 
 
 extern crate libc;
-#[macro_use] extern crate likely;
 
 
 use self::mnemonic_parameter_types::*;

--- a/workspace/assembler/src/tests/mod.rs
+++ b/workspace/assembler/src/tests/mod.rs
@@ -13,7 +13,7 @@ use ::std::io::Write;
 #[test]
 pub fn lifecycle()
 {
-	let mut map = ExecutableAnonymousMemoryMap::new(4096, false).expect("Could not anonymously mmap");
+	let mut map = ExecutableAnonymousMemoryMap::new(4096, false, false).expect("Could not anonymously mmap");
 	let instruction_stream = map.instruction_stream(&InstructionStreamHints::default());
 	
 	instruction_stream.finish();
@@ -22,7 +22,7 @@ pub fn lifecycle()
 #[test]
 pub fn labelling()
 {
-	let mut map = ExecutableAnonymousMemoryMap::new(4096, false).expect("Could not anonymously mmap");
+	let mut map = ExecutableAnonymousMemoryMap::new(4096, false, false).expect("Could not anonymously mmap");
 	let mut instruction_stream = map.instruction_stream(&InstructionStreamHints::default());
 	
 	let label1 = instruction_stream.create_label();
@@ -36,7 +36,7 @@ pub fn labelling()
 #[test]
 pub fn simple_function()
 {
-	let mut map = ExecutableAnonymousMemoryMap::new(4096, false).expect("Could not anonymously mmap");
+	let mut map = ExecutableAnonymousMemoryMap::new(4096, false, false).expect("Could not anonymously mmap");
 	
 	let _function_pointer =
 	{
@@ -66,7 +66,7 @@ pub fn simple_function()
 #[test]
 pub fn validate_that_rust_follows_the_system_v_abi_for_bool()
 {
-	let mut map = ExecutableAnonymousMemoryMap::new(4096, false).expect("Could not anonymously mmap");
+	let mut map = ExecutableAnonymousMemoryMap::new(4096, false, false).expect("Could not anonymously mmap");
 	
 	let false_function_pointer =
 	{
@@ -88,7 +88,7 @@ pub fn validate_that_rust_follows_the_system_v_abi_for_bool()
 	// See AMD64 ABI 1.0 – August 13, 2018 – 8:25, page 22, third-to-last paragraph and footnote 16.
 	// In essence, a _Bool should be interpreted only from the bottom 8 bits.
 	
-	let mut map = ExecutableAnonymousMemoryMap::new(4096, false).expect("Could not anonymously mmap");
+	let mut map = ExecutableAnonymousMemoryMap::new(4096, false, false).expect("Could not anonymously mmap");
 	
 	let false_function_pointer =
 	{
@@ -111,7 +111,7 @@ pub fn validate_that_rust_follows_the_system_v_abi_for_bool()
 #[test]
 pub fn validate_that_rust_follows_the_system_v_abi_for_u128()
 {
-	let mut map = ExecutableAnonymousMemoryMap::new(4096, false).expect("Could not anonymously mmap");
+	let mut map = ExecutableAnonymousMemoryMap::new(4096, false, false).expect("Could not anonymously mmap");
 	
 	let u128_function_pointer: unsafe extern "C" fn() -> u128 =
 	{
@@ -185,7 +185,7 @@ pub fn validate_that_rust_follows_the_system_v_abi_for_u128()
 #[test]
 pub fn emit()
 {
-	let mut map = ExecutableAnonymousMemoryMap::new(4096, false).unwrap();
+	let mut map = ExecutableAnonymousMemoryMap::new(4096, false, false).unwrap();
 	let mut instruction_stream = map.instruction_stream(&InstructionStreamHints::default());
 	
 	let offset: usize = 64;


### PR DESCRIPTION
### Changes
This PR removes a dependency on the `unlikely` crate, which requires a `core_instrinsics` feature that's only available on nightly Rust compilers and is not likely to be stabilized. This means that the `assembler` crate can be built on stable Rust.

It also fixes a build error on OS X when running the test suite.

### Benchmark
This PR adds a performance benchmark using Criterion to validate that removing `unlikely` does not cause a performance regression. Here are the results from my machine:

```
simple function         time:   [9.8875 us 9.9003 us 9.9138 us]                             
                        change: [-0.1239% +0.1406% +0.3807%] (p = 0.29 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```

These were generated by first setting a benchmark with the `unlikely` crate, then comparing the updated version against that benchmark:

```
git reset --hard 4972c2b
cargo +nightly bench --bench performance_tests -- --save-baseline with-unlikely
git reset --hard b7dbb33
cargo +nightly bench --bench performance_tests -- --baseline with-unlikely
```
